### PR TITLE
Add CI

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,28 @@
+---
+Language: Cpp
+BasedOnStyle: Google
+
+TabWidth: 2
+IndentWidth: 2
+AccessModifierOffset: -4
+BraceWrapping:
+  AfterCaseLabel:         true
+  AfterClass:             true
+  AfterControlStatement:  true
+  AfterEnum:              true
+  AfterFunction:          true
+  AfterNamespace:         true
+  AfterObjCDeclaration:   true
+  AfterStruct:            true
+  AfterUnion:             true
+  AfterExternBlock:       true
+  BeforeCatch:            true
+  BeforeElse:             true
+  IndentBraces:           false
+BreakBeforeBraces: Custom
+ColumnLimit: 80
+DerivePointerAlignment: false
+SortIncludes:    true
+PointerAlignment: Left
+ReflowComments: false
+...

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,12 @@
+## Required Info:
+
+1. Operating System:
+2. ROS2 Version:
+3. Version or commit hash:
+
+## Steps to reproduce issue
+
+
+## Expected behavior:
+## Actual behavior:
+## Additional information:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+# Description
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+Fixes # (issue)
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+# How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
+
+# Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules

--- a/.github/node_template.md
+++ b/.github/node_template.md
@@ -1,0 +1,29 @@
+# <NodeNameHere>
+
+## Summary
+
+Summary of functionality
+
+## Topics 
+
+### Publishes
+
+- exampleTopic: description of topic published
+
+### Subscribes
+
+- exampleTopicSub: description of topic subbed
+
+## Params 
+
+- exampleParam: int that does a thing
+
+## Potential Improvements
+
+This node trash
+
+# Launch 
+
+'./path/to/launchfile'
+
+other launchfile stuff people should know, like a usage section

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   # the following line skips the linter which checks for copyrights
   # uncomment the line when a copyright and license is not present in all source files
-  #set(ament_cmake_copyright_FOUND TRUE)
+  set(ament_cmake_copyright_FOUND TRUE)
   # the following line skips cpplint (only works in a git repo)
   # uncomment the line when this package is not in a git repo
   #set(ament_cmake_cpplint_FOUND TRUE)

--- a/include/twist_to_ackermann/tta.hpp
+++ b/include/twist_to_ackermann/tta.hpp
@@ -4,30 +4,36 @@
 #include "ackermann_msgs/msg/ackermann_drive_stamped.hpp"
 #include "geometry_msgs/msg/twist.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
-#include "rclcpp/rclcpp.hpp"
 #include "optional"
+#include "rclcpp/rclcpp.hpp"
 
-namespace tta {
-class TwistToAckermann : public rclcpp::Node {
+namespace tta
+{
+class TwistToAckermann : public rclcpp::Node
+{
 public:
   explicit TwistToAckermann(rclcpp::NodeOptions options);
 
 private:
-  // Without stamps 
-  std::optional<std::shared_ptr<rclcpp::Subscription<geometry_msgs::msg::Twist>>> _twist_sub = std::nullopt;
-  std::optional<std::shared_ptr<rclcpp::Publisher<ackermann_msgs::msg::AckermannDrive>>> _ack_pub = std::nullopt;
-  
+  // Without stamps
+  std::optional<std::shared_ptr<rclcpp::Subscription<geometry_msgs::msg::Twist>>> _twist_sub =
+    std::nullopt;
+  std::optional<std::shared_ptr<rclcpp::Publisher<ackermann_msgs::msg::AckermannDrive>>> _ack_pub =
+    std::nullopt;
+
   // With stamps
-  std::optional<std::shared_ptr<rclcpp::Subscription<geometry_msgs::msg::TwistStamped>>> _twists_sub = std::nullopt;
-  std::optional<std::shared_ptr<rclcpp::Publisher<ackermann_msgs::msg::AckermannDriveStamped>>> _acks_pub = std::nullopt;
-  
+  std::optional<std::shared_ptr<rclcpp::Subscription<geometry_msgs::msg::TwistStamped>>>
+    _twists_sub = std::nullopt;
+  std::optional<std::shared_ptr<rclcpp::Publisher<ackermann_msgs::msg::AckermannDriveStamped>>>
+    _acks_pub = std::nullopt;
+
   /// Wheelbase in meters.
   double _wheelbase{};
-  
+
   /// Whether to use stamped messages.
   bool _use_stamps;
 
   void twist_cb(geometry_msgs::msg::Twist::SharedPtr msg);
   void twists_cb(geometry_msgs::msg::TwistStamped::SharedPtr msg);
 };
-} // namespace tta
+}  // namespace tta

--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,7 @@
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_clang_format</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/package.xml
+++ b/package.xml
@@ -15,8 +15,13 @@
   <depend>ackermann_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_flake8</test_depend>
+  <test_depend>ament_cmake_xmllint</test_depend>
+  <test_depend>ament_cmake_lint_cmake</test_depend>
   <test_depend>ament_cmake_clang_format</test_depend>
+  <test_depend>ament_cmake_cppcheck</test_depend>
+  <test_depend>ament_cmake_pep257</test_depend>
+  <test_depend>ament_clang_tidy</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/twist_to_ackermann.cpp
+++ b/src/twist_to_ackermann.cpp
@@ -7,7 +7,6 @@
 
 namespace tta
 {
-
 /// Finds the appropriate steering angle for some turning radius, which is defined by the
 /// transient velocity of the vehicle along that curve (just the current velocity in this instance),
 /// and the rate that curve changes (angular z rotation). This angle is effected by vehicle wheelbase.

--- a/src/twist_to_ackermann.cpp
+++ b/src/twist_to_ackermann.cpp
@@ -1,18 +1,21 @@
-#include "twist_to_ackermann/tta.hpp"
 #include <cmath>
 #include <functional>
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
 
-namespace tta {
+#include "twist_to_ackermann/tta.hpp"
 
-/// Finds the appropriate steering angle for some turning radius, which is defined by the 
+namespace tta
+{
+
+/// Finds the appropriate steering angle for some turning radius, which is defined by the
 /// transient velocity of the vehicle along that curve (just the current velocity in this instance),
 /// and the rate that curve changes (angular z rotation). This angle is effected by vehicle wheelbase.
 ///
 /// All units are in m/s or r/s.
-double convert_trans_rot_vel_to_steering_angle(double vel, double omega, double wheelbase) {
-  if(omega == 0 || vel == 0) {
+double convert_trans_rot_vel_to_steering_angle(double vel, double omega, double wheelbase)
+{
+  if (omega == 0 || vel == 0) {
     return 0;
   }
 
@@ -24,51 +27,49 @@ double convert_trans_rot_vel_to_steering_angle(double vel, double omega, double 
 }
 
 TwistToAckermann::TwistToAckermann(rclcpp::NodeOptions options)
-    : Node("twist_to_ackermann", options) {
+: Node("twist_to_ackermann", options)
+{
+  _use_stamps = this->declare_parameter("use_stamps", false);
 
-      _use_stamps = this->declare_parameter("use_stamps", false);
+  if (_use_stamps) {
+    _twists_sub = this->create_subscription<geometry_msgs::msg::TwistStamped>(
+      "/nav_vel", 10, std::bind(&TwistToAckermann::twists_cb, this, std::placeholders::_1));
 
-      if(_use_stamps) {
-        _twists_sub = this->create_subscription<geometry_msgs::msg::TwistStamped>(
-          "/nav_vel", 
-          10, 
-          std::bind(&TwistToAckermann::twists_cb, this, std::placeholders::_1)
-          );
-        
-        _acks_pub = this->create_publisher<ackermann_msgs::msg::AckermannDriveStamped>("/ack_vel", 10);
-      } else {
-        _twist_sub = this->create_subscription<geometry_msgs::msg::Twist>(
-          "/nav_vel", 
-          10,
-          std::bind(&TwistToAckermann::twist_cb, this, std::placeholders::_1)
-          );
-        
-        _ack_pub = this->create_publisher<ackermann_msgs::msg::AckermannDrive>("/ack_vel", 10);
-      } 
+    _acks_pub = this->create_publisher<ackermann_msgs::msg::AckermannDriveStamped>("/ack_vel", 10);
+  } else {
+    _twist_sub = this->create_subscription<geometry_msgs::msg::Twist>(
+      "/nav_vel", 10, std::bind(&TwistToAckermann::twist_cb, this, std::placeholders::_1));
 
-      _wheelbase = this->declare_parameter("wheelbase", 1.0);
+    _ack_pub = this->create_publisher<ackermann_msgs::msg::AckermannDrive>("/ack_vel", 10);
+  }
+
+  _wheelbase = this->declare_parameter("wheelbase", 1.0);
 }
 
-void TwistToAckermann::twist_cb(geometry_msgs::msg::Twist::SharedPtr msg) {
+void TwistToAckermann::twist_cb(geometry_msgs::msg::Twist::SharedPtr msg)
+{
   ackermann_msgs::msg::AckermannDrive out{};
   out.speed = msg->linear.x;
-  out.steering_angle = convert_trans_rot_vel_to_steering_angle(msg->linear.x, msg->angular.z, this->_wheelbase);
+  out.steering_angle =
+    convert_trans_rot_vel_to_steering_angle(msg->linear.x, msg->angular.z, this->_wheelbase);
 
   this->_ack_pub->get()->publish(out);
 }
 
-void TwistToAckermann::twists_cb(geometry_msgs::msg::TwistStamped::SharedPtr msg) {
+void TwistToAckermann::twists_cb(geometry_msgs::msg::TwistStamped::SharedPtr msg)
+{
   ackermann_msgs::msg::AckermannDriveStamped out{};
   out.drive.speed = msg->twist.linear.x;
-  out.drive.steering_angle = 
-    convert_trans_rot_vel_to_steering_angle(msg->twist.linear.x, msg->twist.angular.z, this->_wheelbase);
+  out.drive.steering_angle = convert_trans_rot_vel_to_steering_angle(
+    msg->twist.linear.x, msg->twist.angular.z, this->_wheelbase);
 
   this->_acks_pub->get()->publish(out);
 }
 
-} // namespace tta
+}  // namespace tta
 
-int main(int argc, char **argv) {
+int main(int argc, char ** argv)
+{
   rclcpp::init(argc, argv);
   rclcpp::executors::SingleThreadedExecutor exec;
   rclcpp::NodeOptions options;


### PR DESCRIPTION
This commit adds CI to the repo, and also serves as a demo for the CI to be used in Project Pheonix repos as well. 

Linters have been selected to get the most out of the system without going too hard on code style, which can bog things down. I'm using industrial-ci to run the tests, which has been very nice so far.

Going forward, its a good idea to check out more of githubs features, such as requiring reviews for non owners and requiring CI to pass before merging. Also protecting master, setting up a git flow, semver, ect.

closes #2 